### PR TITLE
Add card preview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -133,6 +133,10 @@ body {
 
 /* Card Form */
 
+.CardForm-Wrapper {
+  margin: 32px;
+}
+
 .Form-InputWrapper {
   display: flex;
   flex-direction: column;
@@ -168,4 +172,32 @@ body {
   font-size: 16px;
   border-bottom: 1px solid #ccc;
   cursor: pointer;
+}
+
+/* Card Preview */
+
+.CardPreview-Wrapper {
+  margin: 32px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid #ccc;
+  background-color: #eee;
+  width: 600px;
+  box-shadow: 0px 2px 4px #aaa;
+}
+
+.CardPreview-Text {
+  margin: 48px 0px;
+  padding: 8px 0px;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.CardPreview-PlaceholderText {
+  border-radius: 8px;
+  padding: 8px;
+  background-color: #ddd;
+  color: #444;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,13 @@
 import "./App.css";
-import CardForm from "./components/CardForm";
 import HeaderFooter from "./components/HeaderFooter";
 import Home from "./components/Home";
+import CardBuilder from "./components/CardBuilder";
 
 function App() {
   return (
     <HeaderFooter>
       {/* <Home /> */}
-      <CardForm />
+      <CardBuilder />
     </HeaderFooter>
   );
 }

--- a/src/components/CardBuilder.js
+++ b/src/components/CardBuilder.js
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import CardForm from "./CardForm";
+import CardPreview from "./CardPreview";
+
+export default function CardBuilder() {
+  const [recipientName, setRecipientName] = useState("");
+  const [selectedHolidayName, setSelectedHolidayName] = useState("");
+  const [senderName, setSenderName] = useState("");
+  return (
+    <div style={{ display: "flex" }}>
+      <div className="CardForm-Wrapper">
+        <CardForm
+          recipientName={recipientName}
+          setRecipientName={setRecipientName}
+          selectedHolidayName={selectedHolidayName}
+          setSelectedHolidayName={setSelectedHolidayName}
+          senderName={senderName}
+          setSenderName={setSenderName}
+        />
+      </div>
+      <div className="CardPreview-Wrapper">
+        <CardPreview
+          recipientName={recipientName}
+          selectedHolidayName={selectedHolidayName}
+          senderName={senderName}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/CardForm.js
+++ b/src/components/CardForm.js
@@ -2,12 +2,16 @@ import { useState, useRef } from "react";
 import HolidayPickerModal from "./HolidayPickerModal";
 import LabeledTextInput from "./LabeledTextInput";
 
-export default function CardForm() {
+export default function CardForm({
+  recipientName,
+  setRecipientName,
+  selectedHolidayName,
+  setSelectedHolidayName,
+  senderName,
+  setSenderName,
+}) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [recipientName, setRecipientName] = useState("");
   const [recipientEmail, setRecipientEmail] = useState("");
-  const [selectedHolidayName, setSelectedHolidayName] = useState("");
-  const [senderName, setSenderName] = useState("");
   const [senderEmail, setSenderEmail] = useState("");
   // const exampleRef = useRef();
 

--- a/src/components/CardPreview.js
+++ b/src/components/CardPreview.js
@@ -1,0 +1,40 @@
+export default function CardPreview(props) {
+  const { recipientName, selectedHolidayName, senderName } = props;
+
+  return (
+    <>
+      <div style={{ display: "flex" }}>
+        <div className="CardPreview-Text">Hey&nbsp;</div>
+        {recipientName ? (
+          <div className="CardPreview-Text">{recipientName}</div>
+        ) : (
+          <div className="CardPreview-Text CardPreview-PlaceholderText">
+            Recipient Name
+          </div>
+        )}
+        <div className="CardPreview-Text">!</div>
+      </div>
+      <div style={{ display: "flex" }}>
+        <div className="CardPreview-Text">I hope you have a great&nbsp;</div>
+        {selectedHolidayName ? (
+          <div className="CardPreview-Text">{selectedHolidayName}</div>
+        ) : (
+          <div className="CardPreview-Text CardPreview-PlaceholderText">
+            Holiday
+          </div>
+        )}
+        <div className="CardPreview-Text">!</div>
+      </div>
+      <div style={{ display: "flex" }}>
+        <div className="CardPreview-Text">From&nbsp;</div>
+        {senderName ? (
+          <div className="CardPreview-Text">{senderName}</div>
+        ) : (
+          <div className="CardPreview-Text CardPreview-PlaceholderText">
+            Sender Name
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### What this PR does

Adds a card preview beside the card form. The card preview shows an approximation of each field's label as a placeholder value when no data has been entered for that field yet. Once data is entered in that field, the data is shown instead of the placeholder.

### Screenshots

Card preview with no data shown:
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/22208997/175795553-7a66e9d3-3307-49cc-8104-4fba819fafa5.png">

Card preview with data shown:
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/22208997/175795570-3a198d73-c13e-49fe-934c-0ee8a5dad6a4.png">

### Testing Steps

1. Confirm the UI matches the designs provided in the connected issue.

2.
Given: the card form has no data entered into it
Then: the card preview should be shown with placeholder values where the data will eventually be shown

3.
When: text is entered into the recipient name field
Then: that text should be shown in the corresponding area of the card preview, taking the place of the placeholder text

4.
Given: there is text entered in the recipient name field
When: that text is fully deleted
Then: the placeholder text for that field should be shown in the corresponding area of the card preview

Resolves #4 