### PR TITLE
Add theming support and light and dark themes app-wide

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ function App() {
   return (
     <ThemeProvider>
       <HeaderFooter>
-        {/* <Home /> */}
+        <Home />
         <CardBuilder />
       </HeaderFooter>
     </ThemeProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -2,13 +2,16 @@ import "./App.css";
 import HeaderFooter from "./components/HeaderFooter";
 import Home from "./components/Home";
 import CardBuilder from "./components/CardBuilder";
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 function App() {
   return (
-    <HeaderFooter>
-      {/* <Home /> */}
-      <CardBuilder />
-    </HeaderFooter>
+    <ThemeProvider>
+      <HeaderFooter>
+        {/* <Home /> */}
+        <CardBuilder />
+      </HeaderFooter>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/CardForm.js
+++ b/src/components/CardForm.js
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import HolidayPickerModal from "./HolidayPickerModal";
 import LabeledTextInput from "./LabeledTextInput";
-import { Label, Button } from "./StyledComponents";
+import { Label, Button, Link } from "./StyledComponents";
 
 export default function CardForm({
   recipientName,
@@ -47,12 +47,7 @@ export default function CardForm({
           {selectedHolidayName ? (
             <div style={{ display: "flex" }}>
               <div style={{ marginRight: 16 }}>{selectedHolidayName}</div>
-              <div
-                style={{ color: "#007d80", cursor: "pointer" }}
-                onClick={() => setIsModalOpen(true)}
-              >
-                Edit
-              </div>
+              <Link onClick={() => setIsModalOpen(true)}>Edit</Link>
             </div>
           ) : (
             <Button type="button" onClick={() => setIsModalOpen(true)}>

--- a/src/components/HeaderFooter.js
+++ b/src/components/HeaderFooter.js
@@ -1,15 +1,29 @@
+import { useContext } from "react";
+import { ThemeContext } from "../contexts/ThemeContext";
 import {
   AppBackground,
   FooterCopyright,
   HeaderColorBar,
   HeaderLogo,
 } from "./StyledComponents";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSun, faMoon } from "@fortawesome/free-solid-svg-icons";
 
 export default function HeaderFooter(props) {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+
   return (
     <AppBackground>
       <HeaderColorBar />
-      <HeaderLogo>HappyCards</HeaderLogo>
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <HeaderLogo>HappyCards</HeaderLogo>
+        <div onClick={toggleTheme} style={{ marginTop: 15, marginRight: 20 }}>
+          <FontAwesomeIcon
+            icon={theme === "light" ? faSun : faMoon}
+            size="2x"
+          />
+        </div>
+      </div>
       <div style={{ padding: 40 }}>{props.children}</div>
       <FooterCopyright>&copy; 2022 Andrew Pethoud</FooterCopyright>
     </AppBackground>

--- a/src/components/HolidayPickerModal.js
+++ b/src/components/HolidayPickerModal.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import {
   Input,
   ModalCloseButtonWrapper,
@@ -12,23 +12,9 @@ import _ from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
+import { ThemeContext } from "../contexts/ThemeContext";
 
 const API_KEY = process.env.REACT_APP_HOLIDAYS_API_KEY;
-
-const modalStyles = {
-  overlay: {
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  content: {
-    position: "relative",
-    width: 800,
-    height: 600,
-    inset: 0,
-    padding: 0,
-  },
-};
 
 export default function HolidayPickerModal({
   isModalOpen,
@@ -39,6 +25,43 @@ export default function HolidayPickerModal({
   const [selectedTimeframe, setSelectedTimeframe] = useState("this_month");
   const [holidayList, setHolidayList] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const { theme } = useContext(ThemeContext);
+
+  const modalStyles = {
+    light: {
+      overlay: {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(255, 255, 255, 0.75)",
+      },
+      content: {
+        position: "relative",
+        width: 800,
+        height: 600,
+        inset: 0,
+        padding: 0,
+        backgroundColor: "#fff",
+      },
+    },
+    dark: {
+      overlay: {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(0, 0, 0, 0.75)",
+      },
+      content: {
+        position: "relative",
+        width: 800,
+        height: 600,
+        inset: 0,
+        padding: 0,
+        backgroundColor: "#242327",
+        borderColor: "#504f52",
+      },
+    },
+  };
 
   useEffect(() => {
     async function getHolidays() {
@@ -80,7 +103,7 @@ export default function HolidayPickerModal({
   }
 
   return (
-    <ReactModal isOpen={isModalOpen} style={modalStyles}>
+    <ReactModal isOpen={isModalOpen} style={modalStyles[theme]}>
       <ModalTitleBar>
         <ModalTitle>Pick a Holiday</ModalTitle>
         <ModalCloseButtonWrapper onClick={() => handleCloseModal()}>

--- a/src/components/HolidayPickerModal.js
+++ b/src/components/HolidayPickerModal.js
@@ -6,6 +6,7 @@ import {
   ModalTitle,
   ModalTitleBar,
   TableFilterButton,
+  Text,
 } from "./StyledComponents";
 import ReactModal from "react-modal";
 import _ from "lodash";
@@ -131,9 +132,9 @@ export default function HolidayPickerModal({
         >
           This Year
         </TableFilterButton>
-        <div style={{ padding: 8, fontStyle: "italic" }}>
+        <Text style={{ padding: 8, fontStyle: "italic" }}>
           ({getFilteredHolidayList().length} options)
-        </div>
+        </Text>
       </div>
       {isLoading ? (
         <div className="FullWidthCenteringContainer">

--- a/src/components/HolidayPickerModal.js
+++ b/src/components/HolidayPickerModal.js
@@ -138,7 +138,9 @@ export default function HolidayPickerModal({
       </div>
       {isLoading ? (
         <div className="FullWidthCenteringContainer">
-          <FontAwesomeIcon spin icon={faCircleNotch} size="3x" />
+          <Text>
+            <FontAwesomeIcon spin icon={faCircleNotch} size="3x" />
+          </Text>
         </div>
       ) : holidayList.length > 0 ? (
         getFilteredHolidayList().map((holiday, index) => (
@@ -148,7 +150,7 @@ export default function HolidayPickerModal({
         ))
       ) : (
         <div className="FullWidthCenteringContainer">
-          <div>No holidays found.</div>
+          <Text>No holidays found.</Text>
         </div>
       )}
     </ReactModal>

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -4,16 +4,25 @@ const themes = {
   light: {
     bg: "#fff",
     border: "#ccc",
-    shadow: "#c8c5dc",
-    text: "#000",
-    teal: "darkturquoise",
-    primaryButton: {
+    buttonPrimary: {
       bg: "darkturquoise",
       text: "#000",
     },
-    secondaryButton: {
+    buttonSecondary: {
       bg: "#ddd",
       text: "#000",
+    },
+    shadow: "#c8c5dc",
+    text: "#000",
+    teal: "darkturquoise",
+    preview: {
+      border: "#ccc",
+      bg: "#eee",
+      shadow: "#c8c5dc",
+      placeholder: {
+        bg: "#ddd",
+        text: "#444",
+      },
     },
     purple: "darkslateblue",
     purpleLight: "#9a94bf",
@@ -21,16 +30,25 @@ const themes = {
   dark: {
     bg: "#242327",
     border: "#bfbbd6",
-    shadow: "#222222",
-    text: "#eee",
-    teal: "#009092",
-    primaryButton: {
+    buttonPrimary: {
       bg: "#009092",
       text: "#eee",
     },
-    secondaryButton: {
+    buttonSecondary: {
       bg: "#666",
       text: "#fff",
+    },
+    shadow: "#222",
+    text: "#eee",
+    teal: "#009092",
+    preview: {
+      border: "#5b5a5d",
+      bg: "#3a393d",
+      shadow: "#222",
+      placeholder: {
+        bg: "#504f52",
+        text: "#ccc",
+      },
     },
     purple: "#9853ff",
     purpleLight: "#9a94bf",
@@ -70,14 +88,14 @@ export const Button = styled.button`
   ${({ theme: { theme }, primary }) =>
     primary
       ? `
-        border: 2px solid ${themes[theme].primaryButton.bg};
-        background-color: ${themes[theme].primaryButton.bg};
-        color: ${themes[theme].primaryButton.text};
+        border: 2px solid ${themes[theme].buttonPrimary.bg};
+        background-color: ${themes[theme].buttonPrimary.bg};
+        color: ${themes[theme].buttonPrimary.text};
         `
       : `
-        border: 2px solid ${themes[theme].secondaryButton.bg};
-        background-color: ${themes[theme].secondaryButton.bg};
-        color: ${themes[theme].secondaryButton.text};
+        border: 2px solid ${themes[theme].buttonSecondary.bg};
+        background-color: ${themes[theme].buttonSecondary.bg};
+        color: ${themes[theme].buttonSecondary.text};
         `}
 `;
 
@@ -223,10 +241,10 @@ export const CardPreviewWrapper = styled.div`
   align-items: center;
   width: 600px;
   ${({ theme: { theme } }) => `
-    box-shadow: 0px 2px 4px #aaa;
-    border: 1px solid #ccc;
-    background-color: #eee;
-  `}
+    box-shadow: 0px 2px 4px ${themes[theme].preview.shadow};
+    border: 1px solid ${themes[theme].preview.border};
+    background-color: ${themes[theme].preview.bg};
+  `};
 `;
 
 export const CardPreviewText = styled.div`
@@ -239,6 +257,8 @@ export const CardPreviewText = styled.div`
 export const CardPreviewPlaceholderText = styled(CardPreviewText)`
   border-radius: 8px;
   padding: 8px;
-  background-color: #ddd;
-  color: #444;
+  ${({ theme: { theme } }) => `
+    background-color: ${themes[theme].preview.placeholder.bg};
+    color: ${themes[theme].preview.placeholder.text};
+  `};
 `;

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -1,20 +1,59 @@
 import styled from "styled-components";
 
+const themes = {
+  light: {
+    bg: "#fff",
+    border: "#ccc",
+    text: "#000",
+    teal: "darkturquoise",
+    primaryButton: {
+      bg: "darkturquoise",
+      text: "#fff",
+    },
+    secondaryButton: {
+      bg: "#ddd",
+      text: "#000",
+    },
+    purple: "darkslateblue",
+  },
+  dark: {
+    bg: "#242327",
+    border: "#bfbbd6",
+    text: "#eee",
+    teal: "#007173",
+    primaryButton: {
+      bg: "#007173",
+      text: "#eee",
+    },
+    secondaryButton: {
+      bg: "#888",
+      text: "#000",
+    },
+    purple: "darkslateblue",
+  },
+};
+
 // Global
 
 export const AppBackground = styled.div`
-  background-color: #fff;
+  ${({ theme: { theme } }) => `
+    background-color: ${themes[theme].bg}
+  `}
 `;
 
 export const Text = styled.div`
   font-size: 16px;
-  color: #000;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text}
+  `}
 `;
 
 export const HeaderText = styled(Text)`
   font-size: 20px;
   font-weight: 700;
-  color: #000;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text}
+  `}
 `;
 
 export const Button = styled.button`
@@ -23,17 +62,17 @@ export const Button = styled.button`
   padding: 8px;
   font-size: 16px;
   font-weight: 700;
-  ${(props) =>
-    props.primary
+  ${({ theme: { theme }, primary }) =>
+    primary
       ? `
-        border: 2px solid darkturquoise;
-        background-color: darkturquoise;
-        color: #fff;
+        border: 2px solid ${themes[theme].primaryButton.bg};
+        background-color: ${themes[theme].primaryButton.bg};
+        color: ${themes[theme].primaryButton.text};
         `
       : `
-        border: 2px solid #ddd;
-        background-color: #ddd;
-        color: #333;
+        border: 2px solid ${themes[theme].secondaryButton.bg};
+        background-color: ${themes[theme].secondaryButton.bg};
+        color: ${themes[theme].secondaryButton.text};
         `}
 `;
 
@@ -56,19 +95,28 @@ export const Label = styled.label`
   font-size: 16px;
   font-weight: 700;
   margin-bottom: 8px;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text}
+  `}
 `;
 
 export const Input = styled.input`
-  border: 1px solid #ccc;
   padding: 8px;
   font-size: 16px;
+  ${({ theme: { theme } }) => `
+    border: 1px solid ${themes[theme].border};
+    background-color: ${themes[theme].bg};
+    color: ${themes[theme].text};
+  `}
 `;
 
 // HeaderFooter
 
 export const HeaderColorBar = styled.div`
   height: 4px;
-  background-color: darkturquoise;
+  ${({ theme: { theme } }) => `
+    background-color: ${themes[theme].teal}
+  `}
 `;
 
 export const HeaderLogo = styled.div`
@@ -77,11 +125,18 @@ export const HeaderLogo = styled.div`
   font-family: "Grandstander", cursive;
   font-size: 24px;
   font-weight: bold;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text}
+  `}
 `;
 
 export const FooterCopyright = styled.div`
-  margin: 8px;
+  margin-top: 300px;
+  padding-bottom: 24px;
   text-align: center;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text}
+  `}
 `;
 
 // Home

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -4,6 +4,7 @@ const themes = {
   light: {
     bg: "#fff",
     border: "#ccc",
+    shadow: "#c8c5dc",
     text: "#000",
     teal: "darkturquoise",
     primaryButton: {
@@ -15,10 +16,12 @@ const themes = {
       text: "#000",
     },
     purple: "darkslateblue",
+    purpleLight: "#9a94bf",
   },
   dark: {
     bg: "#242327",
     border: "#bfbbd6",
+    shadow: "#222222",
     text: "#eee",
     teal: "#007173",
     primaryButton: {
@@ -29,7 +32,8 @@ const themes = {
       bg: "#888",
       text: "#000",
     },
-    purple: "darkslateblue",
+    purple: "#8c40ff",
+    purpleLight: "#9a94bf",
   },
 };
 
@@ -144,16 +148,21 @@ export const FooterCopyright = styled.div`
 
 export const HomeHeroHeaderText = styled.div`
   margin: 32px;
-  background-color: darkturquoise;
+  padding: 6px;
   font-size: 32px;
   font-weight: 700;
-  color: #000;
+  ${({ theme: { theme } }) => `
+    background-color: ${themes[theme].teal};
+    color: ${themes[theme].text};
+  `}
 `;
 
 export const HomeHeroSubheadText = styled.div`
   font-size: 24px;
   font-weight: 700;
-  color: #000;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text};
+  `}
 `;
 
 // HighlightCard
@@ -162,15 +171,20 @@ export const HighlightCard = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  box-shadow: 0px 4px 8px #c8c5dc;
-  border: 1px solid #9a94bf;
   border-radius: 10px;
   width: 15vw;
   padding: 20px;
+  ${({ theme: { theme } }) => `
+    box-shadow: 0px 4px 8px ${themes[theme].shadow};
+    border: 1px solid ${themes[theme].purpleLight};
+    background-color: ${themes[theme].bg};
+  `}
 `;
 
 export const HighlightCardIcon = styled.div`
-  color: darkslateblue;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].purple};
+  `}
 `;
 
 // Modal

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -217,11 +217,17 @@ export const ModalTitleBar = styled.div`
 export const ModalTitle = styled.div`
   font-size: 18px;
   font-weight: 700;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text};
+  `}
 `;
 
 export const ModalCloseButtonWrapper = styled.div`
   padding: 4px;
   cursor: pointer;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].text};
+  `}
 `;
 
 export const ModalTableRow = styled.div`

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -29,7 +29,7 @@ const themes = {
   },
   dark: {
     bg: "#242327",
-    border: "#bfbbd6",
+    border: "#666568",
     buttonPrimary: {
       bg: "#009092",
       text: "#eee",
@@ -219,7 +219,7 @@ export const ModalTitle = styled.div`
   font-weight: 700;
   ${({ theme: { theme } }) => `
     color: ${themes[theme].text};
-  `}
+  `};
 `;
 
 export const ModalCloseButtonWrapper = styled.div`
@@ -227,14 +227,17 @@ export const ModalCloseButtonWrapper = styled.div`
   cursor: pointer;
   ${({ theme: { theme } }) => `
     color: ${themes[theme].text};
-  `}
+  `};
 `;
 
 export const ModalTableRow = styled.div`
   padding: 16px;
   font-size: 16px;
-  border-bottom: 1px solid #ccc;
   cursor: pointer;
+  ${({ theme: { theme } }) => `
+    border-bottom: 1px solid ${themes[theme].border};
+    color: ${themes[theme].text};
+  `}
 `;
 
 // Card Preview

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -9,7 +9,7 @@ const themes = {
     teal: "darkturquoise",
     primaryButton: {
       bg: "darkturquoise",
-      text: "#fff",
+      text: "#000",
     },
     secondaryButton: {
       bg: "#ddd",
@@ -29,8 +29,8 @@ const themes = {
       text: "#eee",
     },
     secondaryButton: {
-      bg: "#888",
-      text: "#000",
+      bg: "#666",
+      text: "#fff",
     },
     purple: "#9853ff",
     purpleLight: "#9a94bf",

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -100,17 +100,17 @@ export const Button = styled.button`
 `;
 
 export const TableFilterButton = styled(Button)`
-  ${(props) =>
-    props.selected
+  ${({ selected, theme: { theme } }) =>
+    selected
       ? `
-        border: 2px solid darkslateblue;
-        background-color: darkslateblue;
-        color: #fff;
+        border: 2px solid ${themes[theme].buttonPrimary.bg};
+        background-color: ${themes[theme].buttonPrimary.bg};
+        color: ${themes[theme].buttonPrimary.text};
         `
       : `
-        border: 2px solid #ddd;
-        background-color: #ddd;
-        color: #333;
+        border: 2px solid ${themes[theme].buttonSecondary.bg};
+        background-color: ${themes[theme].buttonSecondary.bg};
+        color: ${themes[theme].buttonSecondary.text};
         `}
 `;
 

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -15,6 +15,7 @@ const themes = {
     shadow: "#c8c5dc",
     text: "#000",
     teal: "darkturquoise",
+    tealText: "#009092",
     preview: {
       border: "#ccc",
       bg: "#eee",
@@ -41,6 +42,7 @@ const themes = {
     shadow: "#222",
     text: "#eee",
     teal: "#009092",
+    tealText: "#73e4e6",
     preview: {
       border: "#5b5a5d",
       bg: "#3a393d",
@@ -112,6 +114,14 @@ export const TableFilterButton = styled(Button)`
         background-color: ${themes[theme].buttonSecondary.bg};
         color: ${themes[theme].buttonSecondary.text};
         `}
+`;
+
+export const Link = styled.div`
+  cursor: pointer;
+  font-weight: 700;
+  ${({ theme: { theme } }) => `
+    color: ${themes[theme].tealText};
+  `}
 `;
 
 export const Label = styled.label`

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -32,7 +32,7 @@ const themes = {
       bg: "#888",
       text: "#000",
     },
-    purple: "#8c40ff",
+    purple: "#9853ff",
     purpleLight: "#9a94bf",
   },
 };

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -23,9 +23,9 @@ const themes = {
     border: "#bfbbd6",
     shadow: "#222222",
     text: "#eee",
-    teal: "#007173",
+    teal: "#009092",
     primaryButton: {
-      bg: "#007173",
+      bg: "#009092",
       text: "#eee",
     },
     secondaryButton: {
@@ -221,10 +221,12 @@ export const CardPreviewWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  border: 1px solid #ccc;
-  background-color: #eee;
   width: 600px;
-  box-shadow: 0px 2px 4px #aaa;
+  ${({ theme: { theme } }) => `
+    box-shadow: 0px 2px 4px #aaa;
+    border: 1px solid #ccc;
+    background-color: #eee;
+  `}
 `;
 
 export const CardPreviewText = styled.div`

--- a/src/components/StyledComponents.js
+++ b/src/components/StyledComponents.js
@@ -37,7 +37,8 @@ const themes = {
 
 export const AppBackground = styled.div`
   ${({ theme: { theme } }) => `
-    background-color: ${themes[theme].bg}
+    background-color: ${themes[theme].bg};
+    color: ${themes[theme].text};
   `}
 `;
 
@@ -52,7 +53,7 @@ export const HeaderText = styled(Text)`
   font-size: 20px;
   font-weight: 700;
   ${({ theme: { theme } }) => `
-    color: ${themes[theme].text}
+    color: ${themes[theme].text};
   `}
 `;
 
@@ -96,7 +97,7 @@ export const Label = styled.label`
   font-weight: 700;
   margin-bottom: 8px;
   ${({ theme: { theme } }) => `
-    color: ${themes[theme].text}
+    color: ${themes[theme].text};
   `}
 `;
 
@@ -115,7 +116,7 @@ export const Input = styled.input`
 export const HeaderColorBar = styled.div`
   height: 4px;
   ${({ theme: { theme } }) => `
-    background-color: ${themes[theme].teal}
+    background-color: ${themes[theme].teal};
   `}
 `;
 
@@ -126,7 +127,7 @@ export const HeaderLogo = styled.div`
   font-size: 24px;
   font-weight: bold;
   ${({ theme: { theme } }) => `
-    color: ${themes[theme].text}
+    color: ${themes[theme].text};
   `}
 `;
 
@@ -135,7 +136,7 @@ export const FooterCopyright = styled.div`
   padding-bottom: 24px;
   text-align: center;
   ${({ theme: { theme } }) => `
-    color: ${themes[theme].text}
+    color: ${themes[theme].text};
   `}
 `;
 

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+import { ThemeProvider as StyledThemeProvider } from "styled-components";
+
+const ThemeContext = React.createContext("light");
+
+const ThemeProvider = (props) => {
+  const [theme, setTheme] = useState("light");
+  const toggleTheme = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <StyledThemeProvider theme={{ theme }}>
+        {props.children}
+      </StyledThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export { ThemeContext, ThemeProvider };


### PR DESCRIPTION
### What this PR does

Adds theming support to the app as well as full light and dark themes app-wide.

### Screenshots

Light theme for app header and home page:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/22208997/177431935-561e7a68-df56-4402-81de-287803a0b442.png">

Light theme for card form:
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/22208997/177432106-68b0ddc0-297f-4e6f-bbe5-d42ac4520417.png">

Light theme for holiday picker modal:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/22208997/177432151-a3d14285-eef9-4f27-9cd4-2dea5244af0d.png">

Dark theme for app header and home page:
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/22208997/177432012-0e63ca78-c38a-4b26-8060-9301d79ce148.png">

Dark theme for card form:
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/22208997/177432058-6381f354-0019-4513-a170-d3d922da83e7.png">

Dark theme for holiday picker modal:
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/22208997/177432186-4e7688cc-8f86-45fa-90ca-fdedd1fa3413.png">

### Testing Steps

1. Confirm that the app looks and works exactly as it did prior to these changes.

Resolves #8